### PR TITLE
fix: pin time crate to <0.3.47 to resolve tauri-utils CI conflict

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,8 @@ dirs = "5.0"  # For path validation in file commands
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif"] }
 # Low-level image bindings for Canny edge detection
 rgb = "0.8"
+# Pin time to avoid conflict with tauri-utils 2.9.2 (missing HourBase trait in 0.3.47+)
+time = ">=0.3.36, <0.3.47"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-opener = "2.0"

--- a/src/stores/project.ts
+++ b/src/stores/project.ts
@@ -12,7 +12,6 @@
 import { defineStore, storeToRefs } from 'pinia'
 import { useVideoStore } from './video'
 import { useExtractionStore } from './extraction'
-import type { VideoMetadata, ROI, ExtractOptions, OCREngine, ProcessingMode } from '@/types/video'
 
 export const useProjectStore = defineStore('project', () => {
   const video = useVideoStore()


### PR DESCRIPTION
CI 无 Cargo.lock 时拉取 time 0.3.48+，移除 HourBase trait 导致 tauri-utils 2.9.2 编译失败。显式锁定 time 版本确保兼容。